### PR TITLE
Remove link to the NixOS Foundation OpenCollective page

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,1 +1,0 @@
-open_collective: nixos


### PR DESCRIPTION
The nix-community org is not affiliated with the NixOS Foundation in any way. Having a link to it can cause confusion about the community structure.